### PR TITLE
Fix font load failure

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -55,7 +55,7 @@ gulp.task('builddoc:watch', function (cb) {
 
 gulp.task('preview', function(cb) {
     return gulp.src('./dst').pipe(exec(
-        'vivliostyle preview --no-sandbox ./dst/index.html', {
+        'vivliostyle preview --no-sandbox ./dst/index.html -r .', {
         continueOnError: false,
         pipeStdout: false
     })).pipe(exec.reporter({
@@ -69,7 +69,7 @@ gulp.task('buildall', gulp.parallel('sass', 'imgcopy', 'builddoc'));
 
 gulp.task('buildpdf', function(cb) {
     return gulp.src('./dst').pipe(exec(
-        'vivliostyle build -o ./dst/output.pdf -s JIS-B5 ' +
+        'vivliostyle build -o ./dst/output.pdf -s JIS-B5 -r . ' +
         '--no-sandbox ./dst/index.html', {
         continueOnError: false,
         pipeStdout: false

--- a/scss/base/_fonts.scss
+++ b/scss/base/_fonts.scss
@@ -1,101 +1,101 @@
 @font-face {
     font-family: 'Noto Sans CJK JP';
     font-weight: 100;
-    src: url('../fonts/noto-cjk/NotoSansCJKjp-Thin.otf');
+    src: url('../../fonts/noto-cjk/NotoSansCJKjp-Thin.otf');
 }
 
 @font-face {
     font-family: 'Noto Sans CJK JP';
     font-weight: 300;
-    src: url('../fonts/noto-cjk/NotoSansCJKjp-Light.otf');
+    src: url('../../fonts/noto-cjk/NotoSansCJKjp-Light.otf');
 }
 
 @font-face {
     font-family: 'Noto Sans CJK JP';
     font-weight: 400;
-    src: url('../fonts/noto-cjk/NotoSansCJKjp-Regular.otf');
+    src: url('../../fonts/noto-cjk/NotoSansCJKjp-Regular.otf');
 }
 
 @font-face {
     font-family: 'Noto Sans CJK JP';
     font-weight: 500;
-    src: url('../fonts/noto-cjk/NotoSansCJKjp-Medium.otf');
+    src: url('../../fonts/noto-cjk/NotoSansCJKjp-Medium.otf');
 }
 
 @font-face {
     font-family: 'Noto Sans CJK JP';
     font-weight: 700;
-    src: url('../fonts/noto-cjk/NotoSansCJKjp-Bold.otf');
+    src: url('../../fonts/noto-cjk/NotoSansCJKjp-Bold.otf');
 }
 
 @font-face {
     font-family: 'Noto Sans CJK JP';
     font-weight: 900;
-    src: url('../fonts/noto-cjk/NotoSansCJKjp-Black.otf');
+    src: url('../../fonts/noto-cjk/NotoSansCJKjp-Black.otf');
 }
 
 @font-face {
     font-family: 'Noto Serif CJK JP';
     font-weight: 200;
-    src: url('../fonts/noto-cjk/NotoSerifCJKjp-ExtraLight.otf');
+    src: url('../../fonts/noto-cjk/NotoSerifCJKjp-ExtraLight.otf');
 }
 
 @font-face {
     font-family: 'Noto Serif CJK JP';
     font-weight: 300;
-    src: url('../fonts/noto-cjk/NotoSerifCJKjp-Light.otf');
+    src: url('../../fonts/noto-cjk/NotoSerifCJKjp-Light.otf');
 }
 
 @font-face {
     font-family: 'Noto Serif CJK JP';
     font-weight: 400;
-    src: url('../fonts/noto-cjk/NotoSerifCJKjp-Regular.otf');
+    src: url('../../fonts/noto-cjk/NotoSerifCJKjp-Regular.otf');
 }
 
 @font-face {
     font-family: 'Noto Serif CJK JP';
     font-weight: 500;
-    src: url('../fonts/noto-cjk/NotoSerifCJKjp-Medium.otf');
+    src: url('../../fonts/noto-cjk/NotoSerifCJKjp-Medium.otf');
 }
 
 @font-face {
     font-family: 'Noto Serif CJK JP';
     font-weight: 600;
-    src: url('../fonts/noto-cjk/NotoSerifCJKjp-SemiBold.otf');
+    src: url('../../fonts/noto-cjk/NotoSerifCJKjp-SemiBold.otf');
 }
 
 @font-face {
     font-family: 'Noto Serif CJK JP';
     font-weight: 700;
-    src: url('../fonts/noto-cjk/NotoSerifCJKjp-Bold.otf');
+    src: url('../../fonts/noto-cjk/NotoSerifCJKjp-Bold.otf');
 }
 
 @font-face {
     font-family: 'Noto Serif CJK JP';
     font-weight: 900;
-    src: url('../fonts/noto-cjk/NotoSerifCJKjp-Black.otf');
+    src: url('../../fonts/noto-cjk/NotoSerifCJKjp-Black.otf');
 }
 
 @font-face {
     font-family: 'IPAGothic';
     font-weight: 400;
-    src: url('../fonts/IPAfont00303/ipag.ttf');
+    src: url('../../fonts/IPAfont00303/ipag.ttf');
 }
 
 @font-face {
     font-family: 'IPAPGothic';
     font-weight: 400;
-    src: url('../fonts/IPAfont00303/ipagp.ttf');
+    src: url('../../fonts/IPAfont00303/ipagp.ttf');
 }
 
 @font-face {
     font-family: 'IPAMincho';
     font-weight: 400;
-    src: url('../fonts/IPAfont00303/ipam.ttf');
+    src: url('../../fonts/IPAfont00303/ipam.ttf');
 }
 
 @font-face {
     font-family: 'IPAPMincho';
     font-weight: 400;
-    src: url('../fonts/IPAfont00303/ipamp.ttf');
+    src: url('../../fonts/IPAfont00303/ipamp.ttf');
 }


### PR DESCRIPTION
## 概要

`font` ディレクトリが `dst` の外にあるため、(S)CSSで指定されたパスではフォントを読み込めていないようでした。フォントのパスを修正し、Vivliostyle CLIの`-r`オプションを使い`font`ディレクトリもホストされるよう修正しています。